### PR TITLE
Add MemberExpansion class for member-related placeholders

### DIFF
--- a/src/core/services/expansions/impl/guild.ts
+++ b/src/core/services/expansions/impl/guild.ts
@@ -65,6 +65,16 @@ export default class GuildExpansion extends Expansion {
         return context.guild.members.cache.filter((m) => m.presence?.status == "dnd" && !m.user.bot).size.toString();
       case 'offline_members':
         return context.guild.members.cache.filter((m) => m.presence?.status == "offline" && !m.user.bot).size.toString();
+      case 'categories':
+        return context.guild.channels.cache.filter((c) => c.type === ChannelType.GuildCategory).size.toString();
+      case 'announcement_channels':
+        return context.guild.channels.cache.filter((c) => c.type === ChannelType.GuildAnnouncement).size.toString();
+      case 'stage_channels':
+        return context.guild.channels.cache.filter((c) => c.type === ChannelType.GuildStageVoice).size.toString();
+      case 'forum_channels':
+        return context.guild.channels.cache.filter((c) => c.type === ChannelType.GuildForum).size.toString();
+      case 'media_channels':
+        return context.guild.channels.cache.filter((c) => c.type === ChannelType.GuildMedia).size.toString();
     }
   }
 }

--- a/src/core/services/expansions/impl/member.ts
+++ b/src/core/services/expansions/impl/member.ts
@@ -1,0 +1,37 @@
+import { Context } from "@contracts";
+import { Expansion } from "../expansion.js";
+
+export default class MemberExpansion extends Expansion {
+    name = 'member';
+
+    async onRequest(context: Context, placeholder: string) {
+        if (!context.member) return
+
+        switch (placeholder) {
+            case 'display_name':
+                return context.member.displayName;
+            case 'server_avatar_url':
+                return (context.member.avatarURL() !== null && context.member.avatarURL() !== context.member.user.avatarURL()) ? context.member.avatarURL({ forceStatic: true }) : null;
+            case 'global_avatar':
+                return context.member.user.avatarURL;
+            case 'timed_out_until_date':
+                return context.member.isCommunicationDisabled() ? context.member.communicationDisabledUntil : null;
+            case 'timed_out_until_timestamp':
+                return context.member.isCommunicationDisabled() ? context.member.communicationDisabledUntilTimestamp : null;
+            case 'joined_at_date':
+                return context.member.joinedAt;
+            case 'joined_at_timestamp':
+                return context.member.joinedTimestamp;
+            case 'pending_membership':
+                return context.member.pending;
+            case 'server_booster':
+                return context.member.premiumSince !== null ? true : false;
+            case 'server_booster_since_date':
+                return context.member.premiumSince;
+            case 'server_booster_since_timestamp':
+                return context.member.premiumSinceTimestamp;
+            case 'user_status':
+                return context.member.presence?.status;
+        }
+    }
+}

--- a/src/core/services/expansions/impl/member.ts
+++ b/src/core/services/expansions/impl/member.ts
@@ -11,25 +11,25 @@ export default class MemberExpansion extends Expansion {
             case 'display_name':
                 return context.member.displayName;
             case 'server_avatar_url':
-                return (context.member.avatarURL() !== null && context.member.avatarURL() !== context.member.user.avatarURL()) ? context.member.avatarURL({ forceStatic: true }) : null;
+                return ((context.member.avatarURL() !== null && context.member.avatarURL() !== context.member.user.avatarURL()) ? context.member.avatarURL({ forceStatic: true }) : null) || undefined;
             case 'global_avatar':
-                return context.member.user.avatarURL;
+                return context.member.user.avatarURL() || undefined;
             case 'timed_out_until_date':
-                return context.member.isCommunicationDisabled() ? context.member.communicationDisabledUntil : null;
+                return (context.member.isCommunicationDisabled() ? context.member.communicationDisabledUntil.toDateString() : null) || undefined;
             case 'timed_out_until_timestamp':
-                return context.member.isCommunicationDisabled() ? context.member.communicationDisabledUntilTimestamp : null;
+                return (context.member.isCommunicationDisabled() ? context.member.communicationDisabledUntilTimestamp.toString() : null) || undefined;
             case 'joined_at_date':
-                return context.member.joinedAt;
+                return context.member.joinedAt?.toDateString() || undefined;
             case 'joined_at_timestamp':
-                return context.member.joinedTimestamp;
+                return context.member.joinedTimestamp?.toString() || undefined;
             case 'pending_membership':
-                return context.member.pending;
+                return context.member.pending ? 'true' : 'false';
             case 'server_booster':
-                return context.member.premiumSince !== null ? true : false;
+                return context.member.premiumSince !== null ? 'true' : 'false';
             case 'server_booster_since_date':
-                return context.member.premiumSince;
+                return context.member.premiumSince?.toDateString();
             case 'server_booster_since_timestamp':
-                return context.member.premiumSinceTimestamp;
+                return context.member.premiumSinceTimestamp?.toString();
             case 'user_status':
                 return context.member.presence?.status;
         }


### PR DESCRIPTION
Added a placeholder expansion for GuildMember. Prefix of `member`

| Placeholder                    | Expected Result                                                                                  | Other Results |
| ------------------------------ | ------------------------------------------------------------------------------------------------ | ------------- |
| display_name                   | Member Nickname or member display name if nickname isn't set                                     |               |
| server_avatar_url              | If a member has a server-defined avatar, returns it's URL. Otherwise returns null                | `null`        |
| global_avatar                  | Member global avatar URL.                                                                        |               |
| timed_out_until_date           | If member is timed out, returns the date they are timed out until, as a DateString.              | `null`        |
| timed_out_until_timestamp      | If member is timed out, returns the timestamp they are timed out until.                          | `null`        |
| joined_at_date                 | Returns the time the member joined the guild, as a DateString.                                   | `null`        |
| joined_at_timestamp            | Returns the time the member joined the guild.                                                    | `null`        |
| pending_membership             | Returns boolean, as string, depending if the member has yet to pass the guild's membership gate. |               |
| server_booster                 | Returns boolean, as string, depending if the member is a server booster.                         | `null`        |
| server_booster_since_date      | Returns the last time the member started boosting the guild, as a DateString.                    | `null`        |
| server_booster_since_timestamp | Returns the last timestamp the member started boosting the guild.                                | `null`        |
| user_status                    | Returns the member status as string, either `Online`, `Do Not Disturb`, `Away`, or `Offline`.    | `null`        |
