### PR TITLE
3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ItsMyBot is a self-hosted modular Discord bot. Developed with TypeScript and Node.js, it is designed to be easily modifiable through a addon system. The core of the bot has limited functionalities to allow room for addons. It is frequently updated to enhance its features and fix bugs. Feel free to join our Discord server to share your suggestions and report any issues.
 
-[Documentation](https://docs.itsme.to/itsmybot) - [Support](https://itsmy.studio/discord) - [Purchase](https://builtbybit.com/resources/24369/) - [Official Addons](https://builtbybit.com/itsmybot)
+[Documentation](https://itsmy.studio/docs/itsmybot) - [Support](https://itsmy.studio/discord) - [Purchase](https://builtbybit.com/resources/24369/) - [Official Addons](https://builtbybit.com/itsmybot)
 
 ## Features
 Here you can find all the main features of the bot's core.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itsmybot",
-  "version": "3.9.7",
+  "version": "3.10.0",
   "description": "",
   "main": "build/index.js",
   "scripts": {
@@ -29,16 +29,16 @@
     "@types/node": "^22.10.2",
     "cpy-cli": "^5.0.0",
     "inquirer": "^9.2.23",
+    "reflect-metadata": "^0.2.2",
     "ts-node": "^10.9.2",
     "tsc-alias": "^1.8.10",
-    "typescript": "^5.4.5",
-    "reflect-metadata": "^0.2.2"
+    "typescript": "^5.4.5"
   },
   "dependencies": {
     "chalk": "^5.4.1",
     "class-transformer": "^0.5.1",
-    "class-validator": "^0.14.1",
-    "discord.js": "^14.24.0",
+    "class-validator": "^0.15.1",
+    "discord.js": "^14.25.1",
     "filtrex": "^3.1.0",
     "jsonwebtoken": "^9.0.2",
     "mariadb": "^3.4.0",
@@ -47,7 +47,7 @@
     "selfsigned": "^2.4.1",
     "sequelize": "^6.37.5",
     "sequelize-typescript": "^2.1.6",
-    "sqlite3": "^5.1.7",
+    "sqlite3": "^6.0.1",
     "yaml": "^2.7.0"
   }
 }

--- a/src/core/contracts/config/config.ts
+++ b/src/core/contracts/config/config.ts
@@ -134,7 +134,7 @@ export class Config {
     const value = this.get(path);
 
     if (TypeCheckers.isStringArray(value)) return value
-    if (TypeCheckers.isString(value)) return [value]
+    if (TypeCheckers.isString(value)) return [value];
 
     throw this.logger.error(`Expected string array at path "${path}"`);
   }

--- a/src/core/contracts/decorators/validator.ts
+++ b/src/core/contracts/decorators/validator.ts
@@ -236,3 +236,15 @@ export class IsValidConditionArgs implements ValidatorConstraintInterface {
     return `Invalid condition arguments for condition ${object?.id ?? '(unknown)'}:`;
   }
 }
+
+@ValidatorConstraint({ name: 'isNumberAndUserMeta', async: false })
+export class IsNumberAndUserMeta implements ValidatorConstraintInterface {
+  validate(value: any, args: ValidationArguments) {
+    const config = args.object as any;
+    return config.type === 'number' && (config.mode === 'user' || config.mode === 'channel');
+  }
+
+  defaultMessage(validationArguments?: ValidationArguments): string {
+    return `The leaderboard configuration is only valid for metas of type number and mode user or channel.`;
+  }
+}

--- a/src/core/contracts/events.ts
+++ b/src/core/contracts/events.ts
@@ -5,7 +5,9 @@ enum BotEvents {
   EveryMinute = 'everyMinute',
   EveryDay = 'everyDay',
   ButtonClick = 'buttonClick',
+  /** @deprecated Use Events.SelectMenuSubmit instead */
   SelectMenu = 'selectMenu',
+  SelectMenuSubmit = 'selectMenuSubmit',
   ModalSubmit = 'modalSubmit',
   VoiceJoin = 'voiceJoin',
   VoiceLeave = 'voiceLeave',

--- a/src/core/contracts/index.ts
+++ b/src/core/contracts/index.ts
@@ -71,3 +71,10 @@ export type ResolvableInteraction =
   | Modal<Addon | undefined>;
 
 export type LabelComponentBuilder = TextInputBuilder | StringSelectMenuBuilder | MentionableSelectMenuBuilder | ChannelSelectMenuBuilder | RoleSelectMenuBuilder | UserSelectMenuBuilder | FileUploadBuilder;
+
+export interface LeaderboardEntry<T = any> {
+  position: number;
+  userId: string;
+  value: number;
+  additionalData?: T;
+}

--- a/src/core/contracts/validators/scripting.ts
+++ b/src/core/contracts/validators/scripting.ts
@@ -140,7 +140,7 @@ class MessageBase extends MessageValidator {}
 class ModalBase extends ModalValidator {
   @IsDefined()
   @IsString()
-  customId: string;
+  'custom-id': string;
 }
 
 export class ActionArgumentsValidator extends applyActionArgumentFields(Bare) {}

--- a/src/core/contracts/validators/scripting.ts
+++ b/src/core/contracts/validators/scripting.ts
@@ -1,7 +1,7 @@
 
 import { Type } from 'class-transformer';
 import { IsString, IsInt, ValidateNested, IsOptional, ValidateIf, IsDefined, Max, Min, IsPositive, IsArray, IsBoolean, IsNumber, Validate } from 'class-validator';
-import { IsPermissionFlag, IsValidActionArgs, IsValidActionId, IsValidConditionArgs, IsValidConditionId, MessageValidator } from '@itsmybot';
+import { IsPermissionFlag, IsValidActionArgs, IsValidActionId, IsValidConditionArgs, IsValidConditionId, MessageValidator, ModalValidator } from '@itsmybot';
 
 export class ConditionArgumentValidator {
   @IsOptional()
@@ -135,41 +135,69 @@ export class PermissionOverwrites {
   deny: string[]
 }
 
-export class ActionArgumentsValidator extends MessageValidator {
-  @IsOptional()
-  @IsInt()
-  @IsPositive()
-  every: number
-
-  @IsOptional()
-  @IsInt()
-  @IsPositive()
-  cooldown: number
-
-  @IsOptional()
-  @IsInt()
-  @IsPositive()
-  delay: number
-
-  @IsOptional()
-  @IsInt()
-  @Min(0)
-  @Max(100)
-  chance: number
+class Bare {}
+class MessageBase extends MessageValidator {}
+class ModalBase extends ModalValidator {
+  @IsDefined()
+  @IsString()
+  customId: string;
 }
 
-export class FollowUpActionArgumentsValidator extends ActionArgumentsValidator {
-  @IsOptional()
-  @IsArray()
-  @ValidateNested({ each: true })
-  @Type(() => ActionValidator)
-  actions: ActionValidator[]
+export class ActionArgumentsValidator extends applyActionArgumentFields(Bare) {}
 
-  @IsOptional()
-  @IsArray()
-  @ValidateNested({ each: true })
-  @Type(() => ActionValidator)
-  'follow-up-actions': ActionValidator[]
+export class ActionArgumentsValidatorWithMessage extends applyActionArgumentFields(MessageBase) {}
+
+export class ActionArgumentsValidatorWithModal extends applyActionArgumentFields(ModalBase) {}
+
+export class FollowUpActionArgumentsValidator extends applyFollowUpFields(ActionArgumentsValidator) {}
+
+export class FollowUpActionArgumentsValidatorWithMessage extends applyFollowUpFields(ActionArgumentsValidatorWithMessage) {}
+
+export class FollowUpActionArgumentsValidatorWithModal extends applyFollowUpFields(ActionArgumentsValidatorWithModal) {}
+
+function applyActionArgumentFields<TBase extends new (...args: any[]) => {}>(Base: TBase) {
+  class Extended extends Base {
+    @IsOptional()
+    @IsInt()
+    @IsPositive()
+    every: number;
+
+    @IsOptional()
+    @IsInt()
+    @IsPositive()
+    cooldown: number;
+
+    @IsOptional()
+    @IsInt()
+    @IsPositive()
+    delay: number;
+
+    @IsOptional()
+    @IsInt()
+    @Min(0)
+    @Max(100)
+    chance: number;
+  };
+
+  return Extended;
+}
+
+function applyFollowUpFields<TBase extends new (...args: any[]) => {}>(Base: TBase) {
+  class Extended extends Base {
+    @IsOptional()
+    @IsArray()
+    @ValidateNested({ each: true })
+    @Type(() => ActionValidator)
+    actions: ActionValidator[];
+
+    @IsOptional()
+    @IsArray()
+    @ValidateNested({ each: true })
+    @Type(() => ActionValidator)
+    'follow-up-actions': ActionValidator[];
+  };
+
+  return Extended;
 }
 
 export class ActionValidator {

--- a/src/core/manager.ts
+++ b/src/core/manager.ts
@@ -112,6 +112,7 @@ export class Manager {
           host: dataConfigFile.getString('host'),
           dialect: dataConfigFile.getString('type') as 'mysql' | 'mariadb',
           logging: dataConfigFile.getBool('debug'),
+          port: dataConfigFile.getNumber('port'),
           dialectOptions: {
             connectTimeout: dataConfigFile.getNumber('connect-timeout'),
           },

--- a/src/core/resources/lang/de.yml
+++ b/src/core/resources/lang/de.yml
@@ -82,9 +82,11 @@ pagination:
   previous-page: Vorherige
 
 leaderboard:
-  messages-format: "`[[position]].` [[position_user_mention]] • **[[position_user_messages]]** gesendete Nachrichten"
   title: "### 🏆 Rangliste – [[leaderboard_name]]"
   footer: Seite [[pagination_current_page]]/[[pagination_total_pages]]
+  entry: "`[[position]].` [[user_mention]] • [[value]]"
+  value:
+    messages: "**[[value]]** nachrichten gesendet"
 
 addons:
   title: Unten findest du die Liste der verfügbaren Addons.

--- a/src/core/resources/lang/en-US.yml
+++ b/src/core/resources/lang/en-US.yml
@@ -82,9 +82,12 @@ pagination:
   previous-page: 'Previous'
 
 leaderboard:
-  messages-format: '`[[position]].` [[position_user_mention]] • **[[position_user_messages]]** messages sent'
   title: "### 🏆 Leaderboard – [[leaderboard_name]]"
+  entry: '`[[position]].` [[user_mention]] • [[value]]'
   footer: "Page [[pagination_current_page]]/[[pagination_total_pages]]"
+  value:
+    messages: '**[[value]]** messages sent'
+
 
 addons:
   title: 'Find below the list of available addons.'

--- a/src/core/resources/lang/es-es.yml
+++ b/src/core/resources/lang/es-es.yml
@@ -82,9 +82,11 @@ pagination:
   previous-page: Anterior
 
 leaderboard:
-  messages-format: "`[[position]].` [[position_user_mention]] • **[[position_user_messages]]** mensajes enviados"
   title: "### 🏆 Clasificación – [[leaderboard_name]]"
   footer: Página [[pagination_current_page]]/[[pagination_total_pages]]
+  entry: "`[[position]].` [[user_mention]] • [[value]]"
+  value:
+    messages: "**[[value]]** mensajes enviados"
 
 addons:
   title: A continuación encontrarás la lista de addons disponibles.

--- a/src/core/resources/lang/fr.yml
+++ b/src/core/resources/lang/fr.yml
@@ -82,9 +82,11 @@ pagination:
   previous-page: Précédent
 
 leaderboard:
-  messages-format: "`[[position]].` [[position_user_mention]] • **[[position_user_messages]]** messages envoyés"
   title: "### 🏆 Classement – [[leaderboard_name]]"
   footer: Page [[pagination_current_page]]/[[pagination_total_pages]]
+  entry: "`[[position]].` [[user_mention]] • [[value]]"
+  value:
+    messages: "**[[value]]** messages envoyés"
 
 addons:
   title: Trouvez ci-dessous la liste des addons disponibles.

--- a/src/core/resources/lang/hu.yml
+++ b/src/core/resources/lang/hu.yml
@@ -82,9 +82,11 @@ pagination:
   previous-page: Előző
 
 leaderboard:
-  messages-format: "`[[position]].` [[position_user_mention]] • **[[position_user_messages]]** üzenet küldve"
   title: "### 🏆 Ranglista – [[leaderboard_name]]"
   footer: Oldal [[pagination_current_page]]/[[pagination_total_pages]]
+  entry: "`[[position]].` [[user_mention]] • [[value]]"
+  value:
+    messages: "**[[value]]** elküldött üzenetek"
 
 addons:
   title: Az alábbiakban található a rendelkezésre álló bővítmények listája.

--- a/src/core/resources/lang/it.yml
+++ b/src/core/resources/lang/it.yml
@@ -82,9 +82,11 @@ pagination:
   previous-page: Precedente
 
 leaderboard:
-  messages-format: "`[[position]].` [[position_user_mention]] • **[[position_user_messages]]** messaggi inviati"
   title: "### 🏆 Classifica – [[leaderboard_name]]"
   footer: Pagina [[pagination_current_page]]/[[pagination_total_pages]]
+  entry: "`[[position]].` [[user_mention]] • [[value]]"
+  value:
+    messages: "**[[value]]** messaggi inviati"
 
 addons:
   title: Trova di seguito l'elenco degli addon disponibili.

--- a/src/core/resources/lang/lt.yml
+++ b/src/core/resources/lang/lt.yml
@@ -82,9 +82,11 @@ pagination:
   previous-page: Ankstesnis
 
 leaderboard:
-  messages-format: "`[[position]].` [[position_user_mention]] • **[[position_user_messages]]** išsiųstų pranešimų"
   title: "### 🏆 Reitingų lenta – [[leaderboard_name]]"
   footer: Puslapis [[pagination_current_page]]/[[pagination_total_pages]]
+  entry: "`[[position]].` [[user_mention]] • [[value]]"
+  value:
+    messages: "**[[value]]** išsiųstų pranešimų"
 
 addons:
   title: Žemiau rasite prieinamų priedų sąrašą.

--- a/src/core/resources/lang/nl.yml
+++ b/src/core/resources/lang/nl.yml
@@ -82,9 +82,11 @@ pagination:
   previous-page: Vorige
 
 leaderboard:
-  messages-format: "`[[position]].` [[position_user_mention]] • **[[position_user_messages]]** berichten verzonden"
   title: "### 🏆 Ranglijst – [[leaderboard_name]]"
   footer: Pagina [[pagination_current_page]]/[[pagination_total_pages]]
+  entry: "`[[position]].` [[user_mention]] • [[value]]"
+  value:
+    messages: "**[[value]]** berichten verzonden"
 
 addons:
   title: Zie hieronder de lijst met beschikbare addons.

--- a/src/core/resources/lang/pl.yml
+++ b/src/core/resources/lang/pl.yml
@@ -82,9 +82,11 @@ pagination:
   previous-page: Poprzednia
 
 leaderboard:
-  messages-format: "`[[position]].` [[position_user_mention]] • **[[position_user_messages]]** wysłanych wiadomości"
   title: "### 🏆 Ranking – [[leaderboard_name]]"
   footer: Strona [[pagination_current_page]]/[[pagination_total_pages]]
+  entry: "`[[position]].` [[user_mention]] • [[value]]"
+  value:
+    messages: "**[[value]]** wysłanych wiadomości"
 
 addons:
   title: Poniżej znajduje się lista dostępnych dodatków.

--- a/src/core/resources/lang/pt-br.yml
+++ b/src/core/resources/lang/pt-br.yml
@@ -82,9 +82,11 @@ pagination:
   previous-page: Anterior
 
 leaderboard:
-  messages-format: "`[[position]].` [[position_user_mention]] • **[[position_user_messages]]** mensagens enviadas"
   title: "### 🏆 Ranking – [[leaderboard_name]]"
   footer: Página [[pagination_current_page]]/[[pagination_total_pages]]
+  entry: "`[[position]].` [[user_mention]] • [[value]]"
+  value:
+    messages: "**[[value]]** mensagens enviadas"
 
 addons:
   title: Encontre abaixo a lista de addons disponíveis.

--- a/src/core/resources/lang/ro.yml
+++ b/src/core/resources/lang/ro.yml
@@ -82,9 +82,11 @@ pagination:
   previous-page: Anterioară
 
 leaderboard:
-  messages-format: "`[[position]].` [[position_user_mention]] • **[[position_user_messages]]** mesaje trimise"
   title: "### 🏆 Clasament – [[leaderboard_name]]"
   footer: Pagina [[pagination_current_page]]/[[pagination_total_pages]]
+  entry: "`[[position]].` [[user_mention]] • [[value]]"
+  value:
+    messages: "**[[value]]** mesaje trimise"
 
 addons:
   title: Mai jos găsiți lista addon-urilor disponibile.

--- a/src/core/resources/lang/ru.yml
+++ b/src/core/resources/lang/ru.yml
@@ -82,9 +82,11 @@ pagination:
   previous-page: Предыдущая
 
 leaderboard:
-  messages-format: "`[[position]].` [[position_user_mention]] • **[[position_user_messages]]** отправлено сообщений"
   title: "### 🏆 Таблица лидеров – [[leaderboard_name]]"
   footer: Страница [[pagination_current_page]]/[[pagination_total_pages]]
+  entry: "`[[position]].` [[user_mention]] • [[value]]"
+  value:
+    messages: "**[[value]]** сообщений отправлено"
 
 addons:
   title: Ниже приведён список доступных аддонов.

--- a/src/core/resources/lang/sv-se.yml
+++ b/src/core/resources/lang/sv-se.yml
@@ -82,9 +82,11 @@ pagination:
   previous-page: Föregående
 
 leaderboard:
-  messages-format: "`[[position]].` [[position_user_mention]] • **[[position_user_messages]]** skickade meddelanden"
   title: "### 🏆 Topplista – [[leaderboard_name]]"
   footer: Sida [[pagination_current_page]]/[[pagination_total_pages]]
+  entry: "`[[position]].` [[user_mention]] • [[value]]"
+  value:
+    messages: "**[[value]]** skickade meddelanden"
 
 addons:
   title: Nedan finns listan över tillgängliga tillägg.

--- a/src/core/resources/lang/tr.yml
+++ b/src/core/resources/lang/tr.yml
@@ -82,9 +82,11 @@ pagination:
   previous-page: Önceki
 
 leaderboard:
-  messages-format: "`[[position]].` [[position_user_mention]] • **[[position_user_messages]]** gönderilen mesaj"
   title: "### 🏆 Liderlik Tablosu – [[leaderboard_name]]"
   footer: Sayfa [[pagination_current_page]]/[[pagination_total_pages]]
+  entry: "`[[position]].` [[user_mention]] • [[value]]"
+  value:
+    messages: "**[[value]]** gönderilen mesajlar"
 
 addons:
   title: Aşağıda mevcut eklentilerin listesi bulunmaktadır.

--- a/src/core/resources/lang/vi.yml
+++ b/src/core/resources/lang/vi.yml
@@ -82,9 +82,11 @@ pagination:
   previous-page: Trước
 
 leaderboard:
-  messages-format: "`[[position]].` [[position_user_mention]] • **[[position_user_messages]]** tin nhắn đã gửi"
   title: "### 🏆 Bảng xếp hạng – [[leaderboard_name]]"
   footer: Trang [[pagination_current_page]]/[[pagination_total_pages]]
+  entry: "`[[position]].` [[user_mention]] • [[value]]"
+  value:
+    messages: "**[[value]]** tin nhắn đã gửi"
 
 addons:
   title: Dưới đây là danh sách addon có sẵn.

--- a/src/core/resources/lang/zh-cn.yml
+++ b/src/core/resources/lang/zh-cn.yml
@@ -1,27 +1,17 @@
 commands:
   addons:
-    description: "Manage addons."
+    description: 管理插件。
     subcommands:
       list:
-        description: "Show the list of addons."
+        description: 显示可用插件列表。
       enable:
-        description: "Enable an addon."
+        description: 启用插件。
         options:
-          addon: "The addon to enable."
+          addon: 要启用的插件。
       disable:
-        description: "Disable an addon."
+        description: 禁用插件。
         options:
-          addon: "The addon to disable."
-    title: 以下是可用插件列表。
-    info: |
-      ### [[addon_status]] [[addon_name]] v[[addon_version]]
-      作者： [[addon_authors]]
-    website: 网站
-    enabled: 插件 `[[addon_name]]` 已启用。重启机器人以应用更改。
-    disabled: 插件 `[[addon_name]]` 已禁用。重启机器人以应用更改。
-    already-enabled: 插件 `[[addon_name]]` 已经启用。
-    already-disabled: 插件 `[[addon_name]]` 已经禁用。
-    not-found: 插件 `[[addon_name]]` 不存在。
+          addon: 要禁用的插件。
   reload:
     description: 重新加载机器人
   parse:
@@ -30,37 +20,28 @@ commands:
       text: 要解析的文本。
       user: 为其解析文本的用户。
   leaderboard:
-    description: "Show the leaderboard."
-    messages-format: "`[[position]].` [[position_user_mention]] • **[[position_user_messages]]** 条消息已发送"
-    title: "### 🏆 排行榜 – [[leaderboard_name]]"
-    footer: 第 [[pagination_current_page]]/[[pagination_total_pages]] 页
+    description: 显示排行榜。
   meta:
-    description: "Manage metadata."
+    description: 管理元数据。
     subcommands:
       set:
-        description: "Set metadata."
+        description: 设置元数据。
       remove:
-        description: "Delete metadata."
+        description: 删除元数据。
       add:
-        description: "Add metadata."
+        description: 添加元数据。
       subtract:
-        description: "Subtract a value from metadata."
+        description: 从元数据中减去一个值。
       toggle:
-        description: "Toggle boolean metadata."
+        description: 切换布尔型元数据。
       list-add:
-        description: "Add a value to list metadata."
+        description: 向列表型元数据添加一个值。
       list-remove:
-        description: "Remove a value from list metadata."
+        description: 从列表型元数据移除一个值。
     options:
-      key: "The key of the metadata."
-      value: "The value of the metadata."
-      scope: "The ID of the channel or user to set the metadata for."
-    scope-required: 此操作需要指定范围。
-    set: 元数据 `[[meta_key]]` 已设置为 `[[meta_value]]`。
-    remove: 元数据 `[[meta_key]]` 已被移除。
-    add: 元数据 `[[meta_key]]` 已添加，值为 `[[meta_value]]`。
-    subtract: 元数据 `[[meta_key]]` 已减去值 `[[meta_value]]`。
-    toggle: 元数据 `[[meta_key]]` 已设置为 `[[meta_value]]`。
+      key: 元数据的键。
+      value: 元数据的值。
+      scope: 要为其设置元数据的频道或用户的ID。
   commands:
     description: 管理机器人命令。
     subcommands:
@@ -85,139 +66,88 @@ commands:
           remove:
             description: 移除命令权限。
             options:
-              command: 要从中移除权限的命令。
-  no-permission: 您没有权限使用该功能。
-  in-cooldown: 您当前处于冷却中。您可以在 [[cooldown]] 后再次执行此操作。
-  only-in-primary-guild: 此操作只能在主公会中使用。
-  invalid-time: 无效的时间格式。请使用有效的时间格式。示例：1d, 1h, 1m, 1s。
-  pagination:
-    select-placeholder: 第 [[pagination_current_page]]/[[pagination_total_pages]] 页
-    placeholder: 选择一个选项
-    no-items: 没有要显示的值。
-    filter-placeholder: 选择筛选器
-    next-page: 下一页
-    previous-page: 上一页
-  reloaded: 机器人已重新加载。部署命令可能需要几秒钟。
-  error-reloading: |
-    ### 重新加载机器人时出错
-    重新加载机器人时发生错误。
-    ```
-    [[error_message]]
-    ```  
-  parsed: |
-    正在为 [[target_mention]] 解析文本：
+              command: 要移除权限的命令。
 
-    ```
-    [[parsed_text]]
-    ```
-  engine:
-    missing-argument: 脚本 `[[script]]` 缺少 `[[missing]]` 参数。
-    missing-context: 脚本 `[[script]]` 缺少 `[[missing]]` 上下文。
-  command:
-    not-found: 命令 `[[command]]` 未找到。
-    enabled: 命令 `[[command]]` 已启用。
-    disabled: 命令 `[[command]]` 已禁用。
-    permission:
-      set: 命令 `[[command]]` 的权限已更新。
-      remove: 命令 `[[command]]` 的权限已被移除。
-      unknown: 无效的权限值。
-  time:
-    short:
-      second: s
-      minute: m
-      hour: h
-      day: d
-      month: m
-    long:
-      second: 秒
-      seconds: 秒
-      minute: 分钟
-      minutes: 分钟
-      hour: 小时
-      hours: 小时
-      day: 天
-      days: 天
-      month: 月
-      months: 月
-
-no-permission: "You don't have permission to use that."
-in-cooldown: "You're currently on cooldown. You can perform this action again [[cooldown]]."
-only-in-primary-guild: "This action can only be used in the primary guild."
-invalid-time: "Invalid time format. Please use a valid time format. Example: 1d, 1h, 1m, 1s."
+no-permission: 你没有权限使用该功能。
+in-cooldown: 你当前处于冷却中。你可以在 [[cooldown]] 后再次执行此操作。
+only-in-primary-guild: 此操作只能在主公会中使用。
+invalid-time: 无效的时间格式。请使用有效的时间格式。例如：1d、1h、1m、1s。
 
 pagination:
-  select-placeholder: "Page [[pagination_current_page]]/[[pagination_total_pages]]"
-  placeholder: "Select an option"
-  no-items: "No values to display."
-  filter-placeholder: "Select a filter"
-  next-page: 'Next'
-  previous-page: 'Previous'
+  select-placeholder: 第 [[pagination_current_page]]/[[pagination_total_pages]] 页
+  placeholder: 选择一个选项
+  no-items: 没有可显示的值。
+  filter-placeholder: 选择筛选条件
+  next-page: 下一页
+  previous-page: 上一页
 
 leaderboard:
-  messages-format: '`[[position]].` [[position_user_mention]] • **[[position_user_messages]]** messages sent'
-  title: "### 🏆 Leaderboard – [[leaderboard_name]]"
-  footer: "Page [[pagination_current_page]]/[[pagination_total_pages]]"
+  title: "### 🏆 排行榜 – [[leaderboard_name]]"
+  entry: "`[[position]].` [[user_mention]] • [[value]]"
+  footer: 第 [[pagination_current_page]]/[[pagination_total_pages]] 页
+  value:
+    messages: "**[[value]]** 条消息已发送"
 
 addons:
-  title: 'Find below the list of available addons.'
+  title: 以下是可用插件列表。
   info: |
     ### [[addon_status]] [[addon_name]] v[[addon_version]]
-    Authors: [[addon_authors]]
-  website: 'Website'
-  enabled: "The addon `[[addon_name]]` has been enabled. Restart the bot to apply the changes."
-  disabled: "The addon `[[addon_name]]` has been disabled. Restart the bot to apply the changes."
-  already-enabled: "The addon `[[addon_name]]` is already enabled."
-  already-disabled: "The addon `[[addon_name]]` is already disabled."
-  not-found: "The addon `[[addon_name]]` doesn't exist."
-reloaded: "The bot has been reloaded. It may take a few seconds to deploy commands."
+    作者：[[addon_authors]]
+  website: 网站
+  enabled: 插件 `[[addon_name]]` 已启用。重启机器人以应用更改。
+  disabled: 插件 `[[addon_name]]` 已禁用。重启机器人以应用更改。
+  already-enabled: 插件 `[[addon_name]]` 已经启用。
+  already-disabled: 插件 `[[addon_name]]` 已经禁用。
+  not-found: 插件 `[[addon_name]]` 不存在。
+reloaded: 机器人已重新加载。部署命令可能需要几秒钟。
 error-reloading: |
-  ### Error while reloading the bot
-  An error occurred while reloading the bot.
+  ### 重新加载机器人时出错
+  重新加载机器人时发生错误。
   ```
   [[error_message]]
   ```  
 parsed: |
-  Parsing the text for [[target_mention]]:
+  正在为 [[target_mention]] 解析文本：
 
   ```
   [[parsed_text]]
   ```
 engine:
-  missing-argument: "The engine `[[engine]]` is missing the `[[missing]]` argument."
-  missing-context: "The script [[script]] is missing the `[[missing]]` context."
+  missing-argument: 脚本 `[[script]]` 缺少 `[[missing]]` 参数。
+  missing-context: 脚本 `[[script]]` 缺少 `[[missing]]` 上下文。
 
 meta:
-  scope-required: "The scope is required for this action."
-  set: "The meta data `[[meta_key]]` has been set to `[[meta_value]]`."
-  remove: "The meta data `[[meta_key]]` has been removed."
-  add: "The meta data `[[meta_key]]` has been added with the value `[[meta_value]]`."
-  subtract: "The meta data `[[meta_key]]` has been subtracted with the value `[[meta_value]]`."
-  toggle: "The meta data `[[meta_key]]` has been set to `[[meta_value]]`."
+  scope-required: 此操作需要指定作用域。
+  set: 元数据 `[[meta_key]]` 已设置为 `[[meta_value]]`。
+  remove: 元数据 `[[meta_key]]` 已被移除。
+  add: 元数据 `[[meta_key]]` 已添加，值为 `[[meta_value]]`。
+  subtract: 元数据 `[[meta_key]]` 已从中减去值 `[[meta_value]]`。
+  toggle: 元数据 `[[meta_key]]` 已设置为 `[[meta_value]]`。
 
 command:
-  not-found: "The command `[[command]]` was not found."
-  enabled: "The command `[[command]]` has been enabled."
-  disabled: "The command `[[command]]` has been disabled."
+  not-found: 未找到命令 `[[command]]`。
+  enabled: 命令 `[[command]]` 已启用。
+  disabled: 命令 `[[command]]` 已禁用。
   permission:
-    set: "The permission for the command `[[command]]` has been updated."
-    remove: "The permission for the command `[[command]]` has been removed."
-    unknown: "Invalid permission value."
+    set: 命令 `[[command]]` 的权限已更新。
+    remove: 命令 `[[command]]` 的权限已被移除。
+    unknown: 无效的权限值。
 
 time:
   short:
-    second: "s"
-    minute: "m"
-    hour: "h"
-    day: "d"
-    month: "m"
+    second: s
+    minute: m
+    hour: h
+    day: d
+    month: m
   long:
-    second: "second"
-    seconds: "seconds"
-    minute: "minute"
-    minutes: "minutes"
-    hour: "hour"
-    hours: "hours"
-    day: "day"
-    days: "days"
-    month: "month"
-    months: "months"
+    second: 秒
+    seconds: 秒
+    minute: 分钟
+    minutes: 分钟
+    hour: 小时
+    hours: 小时
+    day: 天
+    days: 天
+    month: 个月
+    months: 个月

--- a/src/core/resources/scripting/meta.ts
+++ b/src/core/resources/scripting/meta.ts
@@ -1,5 +1,24 @@
 import { Type } from 'class-transformer';
-import { ValidateNested, IsOptional, IsDefined, IsArray, IsString, NotContains, IsIn } from 'class-validator';
+import { ValidateNested, IsOptional, IsDefined, IsArray, IsString, NotContains, IsIn, IsBoolean, Validate } from 'class-validator';
+import { IsNumberAndUserMeta } from '@itsmybot';
+
+class LeaderboardConfig {
+  @IsDefined()
+  @IsBoolean()
+  enabled: boolean
+
+  @IsDefined()
+  @IsString()
+  name: string
+
+  @IsDefined()
+  @IsString()
+  description: string
+
+  @IsOptional()
+  @IsString()
+  format: string
+}
 
 class Meta {
   @IsDefined()
@@ -20,6 +39,12 @@ class Meta {
   @IsString()
   @IsIn(['global', 'user', 'channel', 'message'])
   mode: 'global' | 'user' | 'channel' | 'message'
+
+  @IsOptional()
+  @Validate(IsNumberAndUserMeta)
+  @ValidateNested()
+  @Type(() => LeaderboardConfig)
+  leaderboard?: LeaderboardConfig
 }
 
 export default class DefaultConfig {

--- a/src/core/services/actions/impl/createThread.ts
+++ b/src/core/services/actions/impl/createThread.ts
@@ -1,8 +1,8 @@
-import { Action, ActionData, Context, FollowUpActionArgumentsValidator, Variable, Utils } from '@itsmybot';
+import { Action, ActionData, Context, Variable, Utils, FollowUpActionArgumentsValidatorWithMessage } from '@itsmybot';
 import { IsInt, IsPositive, IsOptional, IsString, IsBoolean } from 'class-validator';
 import { AnyThreadChannel, ChannelType } from 'discord.js';
 
-class ArgumentsValidator extends FollowUpActionArgumentsValidator {
+class ArgumentsValidator extends FollowUpActionArgumentsValidatorWithMessage {
   @IsOptional()
   @IsString({ each: true})
   value: string | string[]

--- a/src/core/services/actions/impl/createThread.ts
+++ b/src/core/services/actions/impl/createThread.ts
@@ -15,6 +15,10 @@ class ArgumentsValidator extends FollowUpActionArgumentsValidatorWithMessage {
   @IsOptional()
   @IsBoolean()
   private: boolean
+
+  @IsOptional()
+  @IsString({ each: true })
+  tags: string | string[]
 }
 
 export default class CreateThreadAction extends Action {

--- a/src/core/services/actions/impl/editMessage.ts
+++ b/src/core/services/actions/impl/editMessage.ts
@@ -1,8 +1,8 @@
-import { Action, ActionData, Context, FollowUpActionArgumentsValidator, Variable, Utils } from '@itsmybot';
+import { Action, ActionData, Context, Variable, Utils, FollowUpActionArgumentsValidatorWithMessage } from '@itsmybot';
 
 export default class EditMessageAction extends Action {
   id = "editMessage";
-  argumentsValidator = FollowUpActionArgumentsValidator;
+  argumentsValidator = FollowUpActionArgumentsValidatorWithMessage;
 
   async onTrigger(script: ActionData, context: Context, variables: Variable[]) {
     if (!context.message) return script.missingContext("message", context);

--- a/src/core/services/actions/impl/randomAction.ts
+++ b/src/core/services/actions/impl/randomAction.ts
@@ -1,11 +1,19 @@
-import { Action, ActionData, Context, FollowUpActionArgumentsValidator, Variable, Utils } from '@itsmybot';
+import { Action, ActionData, Context, Variable, Utils, ActionArgumentsValidator, ActionValidator } from '@itsmybot';
+
+class ArgumentsValidator extends ActionArgumentsValidator {
+  actions: ActionValidator[]
+}
 
 export default class RandomAction extends Action {
   id = "randomAction";
-  argumentsValidator = FollowUpActionArgumentsValidator;
+  argumentsValidator = ArgumentsValidator;
 
   async onTrigger(script: ActionData, context: Context, variables: Variable[]) {
-    script.followUpActions = [Utils.getRandom(script.followUpActions)]
-    this.triggerFollowUpActions(script, context, variables);
+
+    const actions = this.manager.services.action.parseActions(script.args.getSubsections("actions"));
+
+    const action = Utils.getRandom(actions);
+
+    await action.run(context, variables); 
   }
 }

--- a/src/core/services/actions/impl/reply.ts
+++ b/src/core/services/actions/impl/reply.ts
@@ -1,8 +1,8 @@
-import { Action, ActionData, Context, FollowUpActionArgumentsValidator, Variable, Utils } from '@itsmybot';
+import { Action, ActionData, Context, Variable, Utils, FollowUpActionArgumentsValidatorWithMessage } from '@itsmybot';
 
 export default class ReplyAction extends Action {
   id = "reply";
-  argumentsValidator = FollowUpActionArgumentsValidator;
+  argumentsValidator = FollowUpActionArgumentsValidatorWithMessage;
 
   async onTrigger(script: ActionData, context: Context, variables: Variable[]) {
     let message

--- a/src/core/services/actions/impl/sendMessage.ts
+++ b/src/core/services/actions/impl/sendMessage.ts
@@ -1,8 +1,8 @@
-import { Action, ActionData, Context, FollowUpActionArgumentsValidator, Variable, Utils } from '@itsmybot';
+import { Action, ActionData, Context, Variable, Utils, FollowUpActionArgumentsValidatorWithMessage } from '@itsmybot';
 
 export default class SendMessageAction extends Action {
   id = "sendMessage";
-  argumentsValidator = FollowUpActionArgumentsValidator;
+  argumentsValidator = FollowUpActionArgumentsValidatorWithMessage;
 
   async onTrigger(script: ActionData, context: Context, variables: Variable[]) {
     if (!context.channel || !context.channel.isTextBased() || context.channel.isDMBased()) return script.missingContext("channel", context);

--- a/src/core/services/actions/impl/sendPrivateMessage.ts
+++ b/src/core/services/actions/impl/sendPrivateMessage.ts
@@ -1,8 +1,8 @@
-import { Action, ActionData, Context, FollowUpActionArgumentsValidator, Variable, Utils } from '@itsmybot';
+import { Action, ActionData, Context, Variable, Utils, FollowUpActionArgumentsValidatorWithMessage } from '@itsmybot';
 
 export default class SendPrivateMessageAction extends Action {
   id = "sendPrivateMessage";
-  argumentsValidator = FollowUpActionArgumentsValidator;
+  argumentsValidator = FollowUpActionArgumentsValidatorWithMessage;
 
   async onTrigger(script: ActionData, context: Context, variables: Variable[]) {
     if (!context.member) return script.missingContext("member", context);

--- a/src/core/services/actions/impl/showModal.ts
+++ b/src/core/services/actions/impl/showModal.ts
@@ -1,0 +1,13 @@
+import { Action, ActionData, Context, Variable, Utils, ActionArgumentsValidatorWithModal } from '@itsmybot';
+
+export default class ShowModalAction extends Action {
+  id = "showModal";
+  argumentsValidator = ActionArgumentsValidatorWithModal;
+
+  async onTrigger(script: ActionData, context: Context, variables: Variable[]) {
+    if (!context.interaction || context.interaction.isModalSubmit()) return script.missingContext("interaction", context);
+
+    const modal = await Utils.setupModal({ config: script.args, context, variables });
+    await context.interaction.showModal(modal);
+  }
+}

--- a/src/core/services/engine/meta/metaHandler.ts
+++ b/src/core/services/engine/meta/metaHandler.ts
@@ -1,4 +1,4 @@
-import { Manager, MetaData, Service, ConfigFolder, Context } from '@itsmybot';
+import { Manager, MetaData, Service, ConfigFolder, Context, Config, Leaderboard, Utils, manager, Variable, LeaderboardEntry } from '@itsmybot';
 import MetaConfig from '../../../resources/scripting/meta.js';
 
 interface Meta {
@@ -40,17 +40,62 @@ export default class MetaHandler extends Service {
     const metas = await new ConfigFolder(this.manager.logger, 'scripting/metas', 'build/core/resources/scripting/metas').initialize(MetaConfig);
     for (const filePath of metas) {
       for (const config of filePath[1].getSubsections('metas')) {
-        this.registerMeta(
-          config.getString("key"),
-          config.getString("mode") as MetaMode,
-          config.getString("type") as MetaType,
-          config.getStringOrNull("default")
-        );
+        this.registerMeta(config);
       }
     }
   }
 
-  async registerMeta(key: string, mode: MetaMode, type: MetaType, defaultValue?: string) {
+  async registerMeta(config: Config) {
+    const key = config.getString("key");
+    const mode = config.getString("mode") as MetaMode;
+    const type = config.getString("type") as MetaType;
+    let defaultValue = config.getStringOrNull("default");
+
+    const leaderboardConfig = config.getSubsectionOrNull("leaderboard");
+    if (leaderboardConfig && type === MetaType.NUMBER && mode === MetaMode.USER) {
+      const enabled = leaderboardConfig.getBool("enabled");
+      if (enabled) {
+        const name = leaderboardConfig.getString("name");
+        const description = leaderboardConfig.getString("description");
+        const format = leaderboardConfig.getStringOrNull("format")
+        
+        class LeaderboardMeta extends Leaderboard {
+          name = name;
+          description = description;
+        
+          async getData() {
+            const data = await MetaData.findAll({
+              where: {
+                key,
+                mode: mode
+              },
+              order: [['value', 'DESC']]
+            });
+        
+            const formattedData = data.map((metaData, index) => {
+              return { position: index + 1, userId: metaData.scopeId, value: parseFloat(metaData.value) };
+            });
+        
+            return formattedData;
+          }
+
+          formatValue(entry: LeaderboardEntry) {
+            if (!format) return entry.value.toString();
+
+            const variables: Variable[] = [
+              { name: "value", value: entry.value }
+            ];
+
+            return Utils.applyVariables(format, variables);
+            
+          }
+        }
+
+        this.manager.services.leaderboard.registerLeaderboard(new LeaderboardMeta(manager));
+      }
+    }
+
+
     if (this.metas.has(key)) {
       this.manager.logger.warn(`Meta with key ${key} is already registered.`);
       return;

--- a/src/core/services/events/impl/buttonClick.ts
+++ b/src/core/services/events/impl/buttonClick.ts
@@ -7,17 +7,36 @@ export default class ButtonClickEvent extends Event {
   async execute(interaction: ButtonInteraction<'cached'>, user: User) {
     if (!interaction.customId.startsWith("script_")) return;
 
+    const args: string[] = [];
+    let customId = interaction.customId;
+
+    if (interaction.customId.includes(':')) {
+      const split = interaction.customId.match(/('.*?'|".*?"|[^:]+)+/g);
+      if (split) {
+        customId = split[0];
+        args.push(...split.slice(1).map(arg => arg.replace(/^['"]|['"]$/g, '')));
+      }
+    }
+
     const context: Context = {
       guild: interaction.guild || undefined,
       member: interaction.member || undefined,
       user: user,
       channel: interaction.channel || undefined,
-      content: interaction.customId,
+      content: customId,
       interaction: interaction,
       message: interaction.message,
     };
 
-    const variables: Variable[] = [{ name: 'button_custom_id', value: interaction.customId }];
+    const variables: Variable[] = [
+      { name: 'button_custom_id', value: customId },
+      { name: 'button_args_count', value: args.length },
+      { name: 'button_args', value: args.join(', ') }
+    ];
+
+    for (let i = 0; i < args.length; i++) {
+      variables.push({ name: `button_arg_${i}`, value: args[i] });
+    }
 
     this.manager.services.engine.event.emit('buttonClick', context, variables);
   }

--- a/src/core/services/events/impl/interactionCreate.ts
+++ b/src/core/services/events/impl/interactionCreate.ts
@@ -6,19 +6,19 @@ export default class InteractionCreateEvent extends Event {
   name = Events.InteractionCreate;
 
   public async execute(interaction: Interaction<'cached'>) {
-
     const user = interaction.member
       ? await this.manager.services.user.findOrCreate(interaction.member)
       : await this.manager.services.user.findOrNull(interaction.user.id) as User;
 
     if (interaction.isChatInputCommand() || interaction.isAutocomplete() || interaction.isModalSubmit() || interaction.isContextMenuCommand() || interaction.isMessageComponent()) {
       const interactionComponent = this.manager.services.interaction.resolveInteraction(interaction);
-      if (!interactionComponent) {
+
+      if (!interactionComponent && (interaction.isButton() || interaction.isAnySelectMenu() || interaction.isModalSubmit())) {
         if (interaction.isButton()) {
           return this.manager.client.emit(Events.ButtonClick, interaction, user);
         }
         if (interaction.isAnySelectMenu()) {
-          return this.manager.client.emit(Events.SelectMenu, interaction, user);
+          return this.manager.client.emit(Events.SelectMenuSubmit, interaction, user);
         }
         if (interaction.isModalSubmit()) {
           return this.manager.client.emit(Events.ModalSubmit, interaction, user);

--- a/src/core/services/events/impl/messageDelete.ts
+++ b/src/core/services/events/impl/messageDelete.ts
@@ -4,8 +4,10 @@ import { Event, Context, Events, Utils } from '@itsmybot';
 export default class MessageDeleteEvent extends Event {
   name = Events.MessageDelete;
 
-  async execute(message: Message<true>) {
+  async execute(message: Message) {
     if (!message.guild || message.guild.id !== this.manager.primaryGuildId) return;
+    if (!message.author) return;
+    
     const user = message.member ? await this.manager.services.user.findOrCreate(message.member) : await this.manager.services.user.findOrNull(message.author.id);
 
     if (!user) return;

--- a/src/core/services/events/impl/modalSubmit.ts
+++ b/src/core/services/events/impl/modalSubmit.ts
@@ -1,0 +1,76 @@
+import { Event, User, Context, Events, Variable } from '@itsmybot';
+import { ComponentType, ModalSubmitInteraction } from 'discord.js';
+
+export default class ModalSubmitEvent extends Event {
+  name = Events.ModalSubmit;
+
+  async execute(interaction: ModalSubmitInteraction<'cached'>, user: User) {
+    if (!interaction.customId.startsWith("script_")) return;
+
+    const args: string[] = [];
+    let customId = interaction.customId;
+
+    if (interaction.customId.includes(':')) {
+      const split = interaction.customId.match(/('.*?'|".*?"|[^:]+)+/g);
+      if (split) {
+        customId = split[0];
+        args.push(...split.slice(1).map(arg => arg.replace(/^['"]|['"]$/g, '')));
+      }
+    }
+
+    const context: Context = {
+      guild: interaction.guild || undefined,
+      member: interaction.member || undefined,
+      user: user,
+      channel: interaction.channel || undefined,
+      content: customId,
+      interaction: interaction,
+    };
+
+    const variables: Variable[] = [
+      { name: 'modal_custom_id', value: customId },
+      { name: 'modal_args_count', value: args.length },
+      { name: 'modal_args', value: args.join(', ') }
+    ];
+
+    for (let i = 0; i < args.length; i++) {
+      variables.push({ name: `modal_arg_${i}`, value: args[i] });
+    }
+
+    for (const modalComponent of interaction.components) {
+      if (modalComponent.type === ComponentType.Label) {
+        const component = modalComponent.component;
+
+        switch (component.type) {
+          case ComponentType.TextInput:
+            variables.push({ name: `modal_text_input_${component.customId}`, value: component.value });
+            break;
+          case ComponentType.StringSelect:
+            variables.push(
+              { name: `modal_select_${component.customId}_values_count`, value: component.values.length },
+              { name: `modal_select_${component.customId}_values`,value: component.values.join(', ') },
+            );
+
+            for (let i = 0; i < component.values.length; i++) {
+              variables.push({ name: `modal_select_${component.customId}_value_${i}`, value: component.values[i] });
+            }
+
+            break;
+          case ComponentType.FileUpload:
+            variables.push({ name: `modal_file_upload_${component.customId}_attachments_count`, value: component.attachments.size });
+
+            let index = 0;
+
+            component.attachments.forEach(attachment => {
+              variables.push({ name: `modal_file_upload_${component.customId}_attachment_${index}`, value: attachment.url });
+              index++;
+            });
+
+            break;
+        }
+      }
+    }
+
+    this.manager.services.engine.event.emit('modalSubmit', context, variables);
+  }
+};

--- a/src/core/services/events/impl/selectMenuSubmit.ts
+++ b/src/core/services/events/impl/selectMenuSubmit.ts
@@ -1,0 +1,49 @@
+import { Event, User, Context, Events, Variable } from '@itsmybot';
+import { AnySelectMenuInteraction } from 'discord.js';
+
+export default class SelectMenuSubmitEvent extends Event {
+  name = Events.SelectMenuSubmit;
+
+  async execute(interaction: AnySelectMenuInteraction<'cached'>, user: User) {
+    if (!interaction.customId.startsWith("script_")) return;
+
+    const args: string[] = [];
+    let customId = interaction.customId;
+
+    if (interaction.customId.includes(':')) {
+      const split = interaction.customId.match(/('.*?'|".*?"|[^:]+)+/g);
+      if (split) {
+        customId = split[0];
+        args.push(...split.slice(1).map(arg => arg.replace(/^['"]|['"]$/g, '')));
+      }
+    }
+
+    const context: Context = {
+      guild: interaction.guild || undefined,
+      member: interaction.member || undefined,
+      user: user,
+      channel: interaction.channel || undefined,
+      content: customId,
+      interaction: interaction,
+      message: interaction.message,
+    };
+
+    const variables: Variable[] = [
+      { name: 'select_menu_custom_id', value: customId },
+      { name: 'select_menu_values_count', value: interaction.values.length },
+      { name: 'select_menu_values', value: interaction.values.join(', ') },
+      { name: 'select_menu_args_count', value: args.length },
+      { name: 'select_menu_args', value: args.join(', ') }
+    ];
+
+    for (let i = 0; i < interaction.values.length; i++) {
+      variables.push({ name: `select_menu_value_${i}`, value: interaction.values[i] });
+    }
+
+    for (let i = 0; i < args.length; i++) {
+      variables.push({ name: `select_menu_arg_${i}`, value: args[i] });
+    }
+
+    this.manager.services.engine.event.emit('selectMenuSubmit', context, variables);
+  }
+};

--- a/src/core/services/events/impl/voiceStateUpdate.ts
+++ b/src/core/services/events/impl/voiceStateUpdate.ts
@@ -6,6 +6,10 @@ export default class VoiceStateUpdateEvent extends Event {
     priority = 0;
 
     async execute(oldState: VoiceState, newState: VoiceState) {
+        if (oldState.channelId === newState.channelId) {
+            return;
+        }
+
         if (oldState.channel) {
             this.manager.client.emit(Events.VoiceLeave, oldState);
         }

--- a/src/core/services/expansions/impl/leaderboard.ts
+++ b/src/core/services/expansions/impl/leaderboard.ts
@@ -1,0 +1,47 @@
+import { Expansion, Context, Utils } from '@itsmybot';
+
+export default class LeaderboardExpansion extends Expansion {
+  name = 'leaderboard';
+
+  async onRequest(context: Context, placeholder: string) {
+    const [leaderboardName, ...rest] = placeholder.split('_');
+    const subplaceholder = rest.join('_');
+
+    const leaderboard = this.manager.services.leaderboard.leaderboards.get(leaderboardName);
+    if (!leaderboard) return;
+
+    const data = await this.manager.services.leaderboard.getLeaderboardData(leaderboard);
+
+    if (subplaceholder.startsWith('top_')) {
+      const [, positionStr, ...valueNameParts] = subplaceholder.split('_');
+      const valueName = valueNameParts.length ? valueNameParts.join('_') : null;
+      const position = parseInt(positionStr);
+      const entry = data.find(e => e.position === position);
+
+      switch (valueName) {
+        case 'value':
+          return entry ? entry.value.toString() : '0';
+        case 'value_formatted':
+          return entry ? await leaderboard.formatValue(entry) : '0';
+        case null:
+        case 'user':
+          if (!entry) return 'None';
+          const user = await this.manager.services.user.findOrNull(entry.userId);
+          return user ? user.username: 'User not found';
+      }
+
+      if (valueName.startsWith('user_')) {
+        if (!entry) return 'None';
+        const user = await this.manager.services.user.findOrNull(entry.userId);
+        if (!user) return 'User not found';
+
+        const userFormat = await Utils.applyVariables(`[[${valueName}]]`, Utils.userVariables(user));
+        if (userFormat === `[[${valueName}]]`) {
+          return 'Unknown placeholder';
+        }
+
+        return userFormat;
+      }
+    }
+  }
+}

--- a/src/core/services/expansions/impl/owner.ts
+++ b/src/core/services/expansions/impl/owner.ts
@@ -9,6 +9,6 @@ export default class OwnerExpansion extends Expansion {
     const owner = await context.guild.fetchOwner()
     const ownerUser = await this.manager.services.user.findOrCreate(owner);
 
-    return Utils.applyVariables(`%owner_${placeholder}`, Utils.userVariables(ownerUser, 'owner'));
+    return Utils.applyVariables(`[[owner_${placeholder}]]`, Utils.userVariables(ownerUser, 'owner'));
   }
 }

--- a/src/core/services/expansions/impl/role.ts
+++ b/src/core/services/expansions/impl/role.ts
@@ -27,6 +27,8 @@ export default class RoleExpansion extends Expansion {
         return context.role.managed ? 'true' : 'false';
       case 'mentionable':
         return context.role.mentionable ? 'true' : 'false';
+      case 'member_count':
+        return context.role.members.size.toString();
     }
   }
 }

--- a/src/core/services/interactions/impl/metaCommand.ts
+++ b/src/core/services/interactions/impl/metaCommand.ts
@@ -194,7 +194,7 @@ export default class MetaCommand extends Command {
         await meta[subcommand](value); // dynamic call to .add() or .subtract()
         
         return interaction.reply(await this.manager.lang.buildMessage({
-          key: `messages.meta.${subcommand}`,
+          key: `meta.${subcommand}`,
           ephemeral: true,
           variables: [
             { name: "meta_key", value: key },

--- a/src/core/services/interactions/interactionService.ts
+++ b/src/core/services/interactions/interactionService.ts
@@ -137,17 +137,15 @@ export default class InteractionService extends Service {
   }
 
   resolveInteraction(interaction: RepliableInteraction | AutocompleteInteraction): ResolvableInteraction | undefined {
+    if (interaction.isChatInputCommand() || interaction.isAutocomplete() || interaction.isContextMenuCommand()) {
+      return this.getCommand(interaction.commandName) || undefined;
+    }
+
     if (interaction.isButton()) {
       return this.getButton(interaction.customId) || undefined;
     }
     if (interaction.isAnySelectMenu()) {
       return this.getSelectMenu(interaction.customId) || undefined;
-    }
-    if (interaction.isChatInputCommand() || interaction.isAutocomplete()) {
-      return this.getCommand(interaction.commandName) || undefined;
-    }
-    if (interaction.isContextMenuCommand()) {
-      return this.getCommand(interaction.commandName) || undefined;
     }
     if (interaction.isModalSubmit()) {
       return this.getModal(interaction.customId) || undefined;

--- a/src/core/services/leaderboards/impl/messages.ts
+++ b/src/core/services/leaderboards/impl/messages.ts
@@ -1,5 +1,5 @@
 import { Op } from 'sequelize';
-import { User, Leaderboard, Utils } from '@itsmybot';
+import { User, Leaderboard, Variable, Utils, LeaderboardEntry } from '@itsmybot';
 
 export default class MessagesLeaderboard extends Leaderboard {
   name = "messages"
@@ -16,17 +16,20 @@ export default class MessagesLeaderboard extends Leaderboard {
       }
     });
 
-    const messageFormat = this.manager.lang.getString("leaderboard.messages-format")
-
     const formattedData = data.map((user, index) => {
-      const variables = [
-        { name: "position", value: index + 1 },
-        ...Utils.userVariables(user, 'position_user')
-      ];
-
-      return Utils.applyVariables(messageFormat, variables, { user: user })
+      return { position: index + 1, userId: user.id, value: user.messages };
     })
 
-    return Promise.all(formattedData)
+    return formattedData
+  }
+
+  async formatValue(entry: LeaderboardEntry) {
+    const variables: Variable[] = [
+      { name: "value", value: entry.value }
+    ];
+
+    const format = this.manager.lang.getString('leaderboard.value.messages');
+
+    return Utils.applyVariables(format, variables);
   }
 }

--- a/src/core/services/leaderboards/leaderboard.ts
+++ b/src/core/services/leaderboards/leaderboard.ts
@@ -1,8 +1,13 @@
-import { Addon, Base } from '@itsmybot';
+import { Addon, Base, LeaderboardEntry } from '@itsmybot';
+
 
 export abstract class Leaderboard<T extends Addon | undefined = undefined> extends Base<T>{
   abstract name: string;
   abstract description: string;
 
-  abstract getData(): Promise<string[]>;
+  abstract getData(): Promise<LeaderboardEntry[]>;
+
+  formatValue(entry: LeaderboardEntry): string | Promise<string> {
+    return entry.value.toString()
+  }
 }

--- a/src/core/services/leaderboards/leaderboardService.ts
+++ b/src/core/services/leaderboards/leaderboardService.ts
@@ -1,4 +1,4 @@
-import { Manager, Leaderboard, Command, Addon, Service, Utils, Pagination, CommandBuilder, MessageComponentBuilder } from '@itsmybot';
+import { Manager, Leaderboard, Command, Addon, Service, Utils, Pagination, CommandBuilder, MessageComponentBuilder, Variable, LeaderboardEntry } from '@itsmybot';
 import { ChatInputCommandInteraction, Collection, ContainerBuilder, TextDisplayBuilder } from 'discord.js';
 import { glob } from 'fs/promises';
 import { join, dirname } from 'path';
@@ -9,10 +9,12 @@ import { fileURLToPath } from 'url';
  */
 export default class LeaderboardService extends Service{
   leaderboards: Collection<string, Leaderboard<Addon | undefined>>;
+  cachedData: Map<string, { data: LeaderboardEntry[], timestamp: number }>;
 
   constructor(manager: Manager) {
     super(manager);
     this.leaderboards = new Collection();
+    this.cachedData = new Map();
   }
 
   async initialize() {
@@ -50,6 +52,19 @@ export default class LeaderboardService extends Service{
     }
   }
 
+  async getLeaderboardData(leaderboard: Leaderboard<Addon | undefined>): Promise<LeaderboardEntry[]> {
+    if (this.cachedData.has(leaderboard.name)) {
+      const cached = this.cachedData.get(leaderboard.name)!;
+      if (Date.now() - cached.timestamp < 60000) {
+        return cached.data;
+      }
+    }
+
+    const data = await leaderboard.getData();
+    this.cachedData.set(leaderboard.name, { data, timestamp: Date.now() });
+    return data;
+  }
+
   async registerLeaderboards() {
     class LeaderboardCommands extends Command {
 
@@ -75,24 +90,15 @@ export default class LeaderboardService extends Service{
     this.manager.services.interaction.registerCommand(new LeaderboardCommands(this.manager));
   }
 
-  async leaderboardCommand(interaction: ChatInputCommandInteraction<'cached'>, indentifier: string) {
-    const leaderboard = this.leaderboards.get(indentifier)
+  async leaderboardCommand(interaction: ChatInputCommandInteraction<'cached'>, identifier: string) {
+    const leaderboard = this.leaderboards.get(identifier)
     if (!leaderboard) return interaction.reply("Leaderboard not found.");
 
-    const leaderboardData = await leaderboard.getData();
+    const leaderboardData = await this.getLeaderboardData(leaderboard);
     const leaders = []
-    let rank = 0;
 
     for (const row of leaderboardData) {
-      const variables = [
-        { name: "leaderboard_position", value: rank++ },
-        { name: "leaderboard_message", value: row }
-      ];
-
-      leaders.push({
-        item: row,
-        variables: variables,
-      });
+      leaders.push({ item: row });
     }
 
     new Pagination(leaders)
@@ -107,7 +113,18 @@ export default class LeaderboardService extends Service{
         
         const messages = [];
         for (const item of items) {
-          messages.push(item.item);
+          if (!item.item) continue;
+          const user = await this.manager.services.user.findOrNull(item.item.userId);
+          if (!user) continue;
+          const formatedValue = await leaderboard.formatValue(item.item);
+
+          const variables: Variable[] = [
+            { name: "position", value: item.item.position },
+            { name: "value", value: formatedValue },
+            ...Utils.userVariables(user)
+          ];
+
+          messages.push(await this.manager.lang.getParsedString("leaderboard.entry", variables, context));
         }
         container.addTextDisplayComponents(
           new TextDisplayBuilder()

--- a/src/core/utils/setup/setupSelectMenu.ts
+++ b/src/core/utils/setup/setupSelectMenu.ts
@@ -14,10 +14,10 @@ export async function setupSelectMenu(settings: SelectMenuSettings) {
   const variables = settings.variables || [];
   const context = settings.context;
 
-  const customId = config.getString("custom-id");
+  const customId = await Utils.applyVariables(config.getString("custom-id"), variables, context);
   const disabled = config.getBoolOrNull("disabled") || false;
 
-  const placeholder = config.getStringOrNull("placeholder", true);
+  const placeholder = await Utils.applyVariables(config.getStringOrNull("placeholder", true), variables, context);
   const minSelect = config.getNumberOrNull("min-values")
   const maxSelect = config.getNumberOrNull("max-values") || 1;
   const options = config.getSubsectionsOrNull("options");
@@ -31,8 +31,7 @@ export async function setupSelectMenu(settings: SelectMenuSettings) {
     
   if (minSelect) selectMenu.setMinValues(minSelect);
 
-  const placeholderValue = await Utils.applyVariables(placeholder, variables, context);
-  if (placeholderValue) selectMenu.setPlaceholder(placeholderValue);
+  if (placeholder) selectMenu.setPlaceholder(placeholder);
 
   if (dataSource && template) {
     const data = context.data?.get(dataSource);


### PR DESCRIPTION
The wiki was totally reworked, now directly including the message builder & scripts library. The modal builder was also added!
-  https://itsmy.studio/docs/itsmybot

### Changes
-  SelectMenu now supports placeholders inside `custom-id` & `placeholder`
-  Added `%role_member_count%` placeholder
-  New `showModal` action for scripting
-  New `modalSubmit` & `selectMenuSubmit` triggers for scripting
-  Improved VoiceLeave & VoiceJoin event
-  Database now uses the configured port from the configuration
-  `Events.SelectMenu` renamed to `Events.SelectMenuSubmit`
-  All interaction components (button, select menu, modal) now support args for scripting, allowing to put information in the custom-id and retrieve it with placeholders
-  Reworked the leaderboard structures
-  Added leaderboard expansion, with a lot of placeholders for each leaderboard
-  You can now create leaderboards from meta
-  Improved Script config validation to not allow message args when not required
-  Fixed owner expansion not parsing correctly
-  Fixed null error with messageDelete event
-  Fixed meta message not using the right translation key
-  Fixed missing validation for tags inside createThread action